### PR TITLE
A quick addition of multiprocessing.Pool for higher throughput

### DIFF
--- a/vHULK.py
+++ b/vHULK.py
@@ -560,16 +560,23 @@ def main():
     if not hmmscan_dir.is_dir():
         hmmscan_dir.mkdir(parents=True, exist_ok=True)
 
-    count_hmms = 0
-    for faa in valid_faas.values():
-        run_hmmscan(faa, hmmscan_dir, vog_profiles, threads)
-        count_hmms += 1
-        print(
-            "**Done with {} / {} HMMs\r".format(count_hmms, len(valid_faas)),
-            end="",
-        )
-    else:
-        print("\n**Done with HMMscan!")
+#    count_hmms = 0
+#    for faa in valid_faas.values():
+#        run_hmmscan(faa, hmmscan_dir, vog_profiles, threads)
+#        count_hmms += 1
+#        print(
+#            "**Done with {} / {} HMMs\r".format(count_hmms, len(valid_faas)),
+#            end="",
+#        )
+#    else:
+#        print("\n**Done with HMMscan!")
+
+    count_hmms = len(valid_faas)
+    with multiprocessing.Pool(threads) as p:
+        hmmscan_jobs = list(valid_faas.values())
+        run_wrapper = functools.partial(run_hmmscan, output_dir=hmmscan_dir, vogs_hmms=vog_profiles, threads=1)
+        for _ in tqdm.tqdm(p.imap_unordered(run_wrapper, hmmscan_jobs), total=len(prokka_jobs)):
+            pass
 
     print_now()
 


### PR DESCRIPTION
This change is not thoroughly tested nor implemented in a way that I would consider complete. I am providing it just as an exmaple, in case an maintainer wanted to fettle this into vHULK.

The intent is to remove the significant bottleneck that is Prokka annotation. Since Prokka is pretty lightweight, the viral genomes are small, and the tasks are embarrassingly parallel, it would be far faster to parallelise this step in an inverse fashion.

Therefore, I have just quickly hacked in a multiprocessing.Pool and call prokka with a single thread. I have also removed a bit of the print spam and set Prokka's verbose output to `/dev/null`. Because I seem to love staring at progress bars, I also added tqdm.

Instead of what looked to be hours, it now processes my 6200+ viral genomes in under 7 minutes with 50 cpus.

Now that the job is on to the step of hmmscan, I see that using the above strategy, it also would likely enjoy a similar speed up.